### PR TITLE
[WIP] Improve HTTP Request Tasks

### DIFF
--- a/app/src/main/java/justbe/mindfulnessapp/models/BaseModel.java
+++ b/app/src/main/java/justbe/mindfulnessapp/models/BaseModel.java
@@ -1,9 +1,14 @@
 package justbe.mindfulnessapp.models;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import justbe.mindfulnessapp.rest.ResponseMeta;
+import justbe.mindfulnessapp.rest.UserDataError;
+
 /**
  * Created by eddiehurtig on 11/20/15.
  */
-public abstract class BaseModel {
+public abstract class BaseModel<T> {
 
     private String resource_uri;
 
@@ -17,5 +22,128 @@ public abstract class BaseModel {
 
     public void setResource_uri(String resource_uri) {
         this.resource_uri = resource_uri;
+    }
+
+    /**
+     * The list of objects returned by the api
+     */
+    private T[] objects;
+
+    /**
+     * Metadata returned in the response
+     */
+    private ResponseMeta meta;
+
+    /**
+     * A Python Error Message (Normally the prequel to a stacktrace)
+     */
+    private String error_message;
+
+    /**
+     * A python stacktrace
+     */
+    private String traceback;
+
+    /**
+     * A predicatable error that is normally resolvable by the user
+     */
+    private UserDataError error;
+
+
+    /**
+     * Looks at the entire request and determines the best error message to present
+     * @return The best error message to present
+     */
+    public String getErrorMessage() {
+        if (this.error != null) {
+            return this.error.getMessage();
+        } else if (this.error_message != null) {
+            return this.error_message;
+        } else {
+            return null;
+        }
+    }
+
+    /*******************
+     * GETTERS/SETTERS *
+     ******************/
+
+    /**
+     * Gets the objects
+     * @return The Objects
+     */
+    public T[] getObjects() {
+        return objects;
+    }
+
+    /**
+     * Sets the objects
+     * @param objects The new objects
+     */
+    public void setObjects(T[] objects) {
+        this.objects = objects;
+    }
+
+    /**
+     * Gets the metadata object
+     * @return The metadata object
+     */
+    public ResponseMeta getMeta() { return meta; }
+
+    /**
+     * Sets the metadata object
+     * @param meta The metadata object
+     */
+    public void setMeta(ResponseMeta meta) {
+        this.meta = meta;
+    }
+
+    /**
+     * Gets the python error message precluding a stacktrace
+     * @return the python error message
+     */
+    public String getError_message() {
+        return error_message;
+    }
+
+    /**
+     * Sets a python error message
+     * @param error_message The error message
+     */
+    public void setError_message(String error_message) {
+        this.error_message = error_message;
+    }
+
+    /**
+     * Gets the traceback
+     * @return The traceback
+     */
+    public String getTraceback() {
+        return traceback;
+    }
+
+    /**
+     * Sets the traceback
+     * @param traceback The traceback
+     */
+    public void setTraceback(String traceback) {
+        this.traceback = traceback;
+    }
+
+
+    /**
+     * Gets the UserDataError
+     * @return The UserDataError
+     */
+    public UserDataError getError() {
+        return this.error;
+    }
+
+    /**
+     * Sets the UserDataError message
+     * @param error the UserDataErrorMessage
+     */
+    public void setError(UserDataError error) {
+        this.error = error;
     }
 }

--- a/app/src/main/java/justbe/mindfulnessapp/models/User.java
+++ b/app/src/main/java/justbe/mindfulnessapp/models/User.java
@@ -3,7 +3,7 @@ package justbe.mindfulnessapp.models;
 /**
  * Created by eddiehurtig on 11/20/15.
  */
-public class User extends BaseModel {
+public class User extends BaseModel<User> {
 
     public enum Gender {
         MALE(0), FEMALE(1), OTHER(2);

--- a/app/src/main/java/justbe/mindfulnessapp/rest/GenericHttpRequestTask.java
+++ b/app/src/main/java/justbe/mindfulnessapp/rest/GenericHttpRequestTask.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 
@@ -35,9 +36,28 @@ import java.util.Set;
  *
  * @author edhurtig
  */
-public class GenericHttpRequestTask<S, T> extends AsyncTask<Object, Void, ResponseEntity<ResponseWrapper<T>>> {
+public class GenericHttpRequestTask<S, T> extends AsyncTask<Object, Void, ResponseEntity<T>> {
 
-    protected ResponseEntity<ResponseWrapper<T>> doInBackground(Object... params) {
+    Class provides;
+
+    Class yields;
+
+
+    GenericHttpRequestTask() {
+
+    }
+
+    GenericHttpRequestTask(Class provides, Class yields) {
+        this.provides = provides;
+        this.yields = yields;
+    }
+
+    GenericHttpRequestTask(Object provides, Object yields) {
+        this.provides = provides.getClass();
+        this.yields = yields.getClass();
+    }
+
+    protected ResponseEntity<T> doInBackground(Object... params) {
 
         String url = (String) params[0];
         if (!url.startsWith("http")) {
@@ -81,14 +101,14 @@ public class GenericHttpRequestTask<S, T> extends AsyncTask<Object, Void, Respon
         HttpEntity<S> entity = new HttpEntity<S>(body, headers);
 
         Map<String, Object> uriVariables = new HashMap<String, Object>();
-        ResponseEntity<ResponseWrapper<T>> response;
+        ResponseEntity<T> response;
         try {
             // Send the request
             response = restTemplate.exchange(
                     url,
                     method,
                     entity,
-                    new ParameterizedTypeReference<ResponseWrapper<T>>() {},
+                    this.yields,
                     uriVariables);
             Log.i("REST", url + " " + response.getStatusCode().toString());
             return response;

--- a/app/src/main/java/justbe/mindfulnessapp/rest/ResponseWrapper.java
+++ b/app/src/main/java/justbe/mindfulnessapp/rest/ResponseWrapper.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  *        single resource
  * </p>
  * @param <T>
+ * @deprecated
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ResponseWrapper <T> {


### PR DESCRIPTION
This should allow us to handle responses for single objects... such as the request

`http://secure-headland-8362.herokuapp.com/api/v1/user/119/`

executing a `GET` on that URL provides JSON for a single user.  It should return a single `User` Java Object... which we now support

``
