### PR TITLE
Improve HTTP Request Tasks - Again

### DIFF
--- a/app/src/main/java/justbe/mindfulnessapp/CreateAccountActivity.java
+++ b/app/src/main/java/justbe/mindfulnessapp/CreateAccountActivity.java
@@ -74,13 +74,14 @@ public class CreateAccountActivity extends AppCompatActivity {
     public void createAccountPressed(View view) {
         if ( validateActivity() ) {
             User u = createUser();
+
             // Create an HTTPRequestTask that sends a User Object and Returns a User Object
-            GenericHttpRequestTask<User, String> task = new GenericHttpRequestTask();
+            GenericHttpRequestTask<User, User> task = new GenericHttpRequestTask(User.class, User.class);
 
             task.execute("/api/v1/create_user/", HttpMethod.POST, u);
 
             try {
-                ResponseEntity<ResponseWrapper<String>> result = task.get(5000, TimeUnit.SECONDS);
+                ResponseEntity<User> result = task.waitForResponse();
 
                 RestUtil.checkResponseHazardously(result);
 

--- a/app/src/main/java/justbe/mindfulnessapp/models/BaseModel.java
+++ b/app/src/main/java/justbe/mindfulnessapp/models/BaseModel.java
@@ -1,9 +1,14 @@
 package justbe.mindfulnessapp.models;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import justbe.mindfulnessapp.rest.ResponseMeta;
+import justbe.mindfulnessapp.rest.UserDataError;
+
 /**
  * Created by eddiehurtig on 11/20/15.
  */
-public abstract class BaseModel {
+public abstract class BaseModel<T> {
 
     private String resource_uri;
 
@@ -17,5 +22,128 @@ public abstract class BaseModel {
 
     public void setResource_uri(String resource_uri) {
         this.resource_uri = resource_uri;
+    }
+
+    /**
+     * The list of objects returned by the api
+     */
+    private T[] objects;
+
+    /**
+     * Metadata returned in the response
+     */
+    private ResponseMeta meta;
+
+    /**
+     * A Python Error Message (Normally the prequel to a stacktrace)
+     */
+    private String error_message;
+
+    /**
+     * A python stacktrace
+     */
+    private String traceback;
+
+    /**
+     * A predicatable error that is normally resolvable by the user
+     */
+    private UserDataError error;
+
+
+    /**
+     * Looks at the entire request and determines the best error message to present
+     * @return The best error message to present
+     */
+    public String getErrorMessage() {
+        if (this.error != null) {
+            return this.error.getMessage();
+        } else if (this.error_message != null) {
+            return this.error_message;
+        } else {
+            return null;
+        }
+    }
+
+    /*******************
+     * GETTERS/SETTERS *
+     ******************/
+
+    /**
+     * Gets the objects
+     * @return The Objects
+     */
+    public T[] getObjects() {
+        return objects;
+    }
+
+    /**
+     * Sets the objects
+     * @param objects The new objects
+     */
+    public void setObjects(T[] objects) {
+        this.objects = objects;
+    }
+
+    /**
+     * Gets the metadata object
+     * @return The metadata object
+     */
+    public ResponseMeta getMeta() { return meta; }
+
+    /**
+     * Sets the metadata object
+     * @param meta The metadata object
+     */
+    public void setMeta(ResponseMeta meta) {
+        this.meta = meta;
+    }
+
+    /**
+     * Gets the python error message precluding a stacktrace
+     * @return the python error message
+     */
+    public String getError_message() {
+        return error_message;
+    }
+
+    /**
+     * Sets a python error message
+     * @param error_message The error message
+     */
+    public void setError_message(String error_message) {
+        this.error_message = error_message;
+    }
+
+    /**
+     * Gets the traceback
+     * @return The traceback
+     */
+    public String getTraceback() {
+        return traceback;
+    }
+
+    /**
+     * Sets the traceback
+     * @param traceback The traceback
+     */
+    public void setTraceback(String traceback) {
+        this.traceback = traceback;
+    }
+
+
+    /**
+     * Gets the UserDataError
+     * @return The UserDataError
+     */
+    public UserDataError getError() {
+        return this.error;
+    }
+
+    /**
+     * Sets the UserDataError message
+     * @param error the UserDataErrorMessage
+     */
+    public void setError(UserDataError error) {
+        this.error = error;
     }
 }

--- a/app/src/main/java/justbe/mindfulnessapp/models/BaseModel.java
+++ b/app/src/main/java/justbe/mindfulnessapp/models/BaseModel.java
@@ -1,6 +1,8 @@
 package justbe.mindfulnessapp.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Arrays;
+import java.util.Iterator;
 
 import justbe.mindfulnessapp.rest.ResponseMeta;
 import justbe.mindfulnessapp.rest.UserDataError;
@@ -8,21 +10,13 @@ import justbe.mindfulnessapp.rest.UserDataError;
 /**
  * Created by eddiehurtig on 11/20/15.
  */
-public abstract class BaseModel<T> {
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class BaseModel<T> implements Iterable<T> {
 
+    /**
+     * The URI to the resource... used if you want to get the single detail response of the resource
+     */
     private String resource_uri;
-
-    public Boolean isValid() {
-        return null;
-    }
-
-    public String getResource_uri() {
-        return resource_uri;
-    }
-
-    public void setResource_uri(String resource_uri) {
-        this.resource_uri = resource_uri;
-    }
 
     /**
      * The list of objects returned by the api
@@ -49,6 +43,16 @@ public abstract class BaseModel<T> {
      */
     private UserDataError error;
 
+    /**
+     * A way of determining if the resource is valid, used before sending a request with an instance
+     * of a model as the body, will refuse to send the request if isValid returns false.  Will send
+     * request if isValid returns true or null
+     *
+     * @return True if the resource is valid, false if it is not, null if unknown.
+     */
+    public Boolean isValid() {
+        return null;
+    }
 
     /**
      * Looks at the entire request and determines the best error message to present
@@ -67,6 +71,23 @@ public abstract class BaseModel<T> {
     /*******************
      * GETTERS/SETTERS *
      ******************/
+
+    /**
+     * Gets the resource URI
+     * @return The URI of the resource
+     */
+    public String getResource_uri() {
+        return resource_uri;
+    }
+
+    /**
+     * Sets the resource URI
+     * @param resource_uri The URI of the resource
+     */
+    public void setResource_uri(String resource_uri) {
+        this.resource_uri = resource_uri;
+    }
+
 
     /**
      * Gets the objects
@@ -145,5 +166,18 @@ public abstract class BaseModel<T> {
      */
     public void setError(UserDataError error) {
         this.error = error;
+    }
+
+    /*****************
+     * Extra Methods *
+     *****************/
+
+    /**
+     * Provides a way of iterating over the objects array when a list response is returned.
+     * @return An Iterator for the objects array
+     */
+    @Override
+    public Iterator<T> iterator() {
+        return Arrays.asList(this.objects).iterator();
     }
 }

--- a/app/src/main/java/justbe/mindfulnessapp/models/Success.java
+++ b/app/src/main/java/justbe/mindfulnessapp/models/Success.java
@@ -1,0 +1,16 @@
+package justbe.mindfulnessapp.models;
+
+/**
+ * Created by eddiehurtig on 11/23/15.
+ */
+public class Success extends BaseModel<Success> {
+    private Boolean success;
+
+    public Boolean getSuccess() {
+        return success;
+    }
+
+    public void setSuccess(Boolean success) {
+        this.success = success;
+    }
+}

--- a/app/src/main/java/justbe/mindfulnessapp/models/User.java
+++ b/app/src/main/java/justbe/mindfulnessapp/models/User.java
@@ -3,7 +3,7 @@ package justbe.mindfulnessapp.models;
 /**
  * Created by eddiehurtig on 11/20/15.
  */
-public class User extends BaseModel {
+public class User extends BaseModel<User> {
 
     public enum Gender {
         MALE(0), FEMALE(1), OTHER(2);

--- a/app/src/main/java/justbe/mindfulnessapp/rest/GenericHttpRequestTask.java
+++ b/app/src/main/java/justbe/mindfulnessapp/rest/GenericHttpRequestTask.java
@@ -20,8 +20,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-
 import justbe.mindfulnessapp.App;
+import justbe.mindfulnessapp.models.BaseModel;
 
 
 /**
@@ -38,23 +38,23 @@ import justbe.mindfulnessapp.App;
  *
  * @author edhurtig
  */
-public class GenericHttpRequestTask<S, T> extends AsyncTask<Object, Void, ResponseEntity<T>> {
+public class GenericHttpRequestTask<S, T extends BaseModel> extends AsyncTask<Object, Void, ResponseEntity<T>> {
 
     Class provides;
 
     Class yields;
 
 
-    GenericHttpRequestTask() {
+    public GenericHttpRequestTask() {
 
     }
 
-    GenericHttpRequestTask(Class provides, Class yields) {
+    public GenericHttpRequestTask(Class provides, Class yields) {
         this.provides = provides;
         this.yields = yields;
     }
 
-    GenericHttpRequestTask(Object provides, Object yields) {
+    public GenericHttpRequestTask(Object provides, Object yields) {
         this.provides = provides.getClass();
         this.yields = yields.getClass();
     }

--- a/app/src/main/java/justbe/mindfulnessapp/rest/GenericHttpRequestTask.java
+++ b/app/src/main/java/justbe/mindfulnessapp/rest/GenericHttpRequestTask.java
@@ -20,6 +20,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
 import justbe.mindfulnessapp.App;
 import justbe.mindfulnessapp.models.BaseModel;
 
@@ -123,5 +127,16 @@ public class GenericHttpRequestTask<S, T extends BaseModel> extends AsyncTask<Ob
             Log.i("REST", url + " " + e.getMessage());
             return null;
         }
+    }
+
+    /**
+     * Waits for a response from the API for a consistent amount of time
+     * @return
+     * @throws InterruptedException
+     * @throws ExecutionException
+     * @throws TimeoutException
+     */
+    public ResponseEntity<T> waitForResponse() throws InterruptedException, ExecutionException, TimeoutException {
+        return this.get(25, TimeUnit.SECONDS);
     }
 }

--- a/app/src/main/java/justbe/mindfulnessapp/rest/GenericHttpRequestTask.java
+++ b/app/src/main/java/justbe/mindfulnessapp/rest/GenericHttpRequestTask.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import justbe.mindfulnessapp.App;
@@ -37,9 +38,28 @@ import justbe.mindfulnessapp.App;
  *
  * @author edhurtig
  */
-public class GenericHttpRequestTask<S, T> extends AsyncTask<Object, Void, ResponseEntity<ResponseWrapper<T>>> {
+public class GenericHttpRequestTask<S, T> extends AsyncTask<Object, Void, ResponseEntity<T>> {
 
-    protected ResponseEntity<ResponseWrapper<T>> doInBackground(Object... params) {
+    Class provides;
+
+    Class yields;
+
+
+    GenericHttpRequestTask() {
+
+    }
+
+    GenericHttpRequestTask(Class provides, Class yields) {
+        this.provides = provides;
+        this.yields = yields;
+    }
+
+    GenericHttpRequestTask(Object provides, Object yields) {
+        this.provides = provides.getClass();
+        this.yields = yields.getClass();
+    }
+
+    protected ResponseEntity<T> doInBackground(Object... params) {
 
         String url = (String) params[0];
         if (!url.startsWith("http")) {
@@ -88,14 +108,14 @@ public class GenericHttpRequestTask<S, T> extends AsyncTask<Object, Void, Respon
         HttpEntity<S> entity = new HttpEntity<S>(body, headers);
 
         Map<String, Object> uriVariables = new HashMap<String, Object>();
-        ResponseEntity<ResponseWrapper<T>> response;
+        ResponseEntity<T> response;
         try {
             // Send the request
             response = restTemplate.exchange(
                     url,
                     method,
                     entity,
-                    new ParameterizedTypeReference<ResponseWrapper<T>>() {},
+                    this.yields,
                     uriVariables);
             Log.i("REST", url + " " + response.getStatusCode().toString());
             return response;

--- a/app/src/main/java/justbe/mindfulnessapp/rest/ResponseWrapper.java
+++ b/app/src/main/java/justbe/mindfulnessapp/rest/ResponseWrapper.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  *        single resource
  * </p>
  * @param <T>
+ * @deprecated
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ResponseWrapper <T> {

--- a/app/src/main/java/justbe/mindfulnessapp/rest/RestUtil.java
+++ b/app/src/main/java/justbe/mindfulnessapp/rest/RestUtil.java
@@ -4,6 +4,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestClientException;
 
+import justbe.mindfulnessapp.models.BaseModel;
+
 /**
  * Static utilities for Rest API Requests
  *
@@ -16,7 +18,7 @@ public class RestUtil {
      * @param response The response from the server
      * @param <T> The type of the object in the {@link ResponseWrapper}
      */
-    public static <T> void checkResponseHazardously(ResponseEntity<ResponseWrapper<T>> response)
+    public static <T> void checkResponseHazardously(ResponseEntity<? extends BaseModel> response)
             throws UserDataError, RestClientException {
         if (response == null) {
             throw new RestClientException(
@@ -37,7 +39,7 @@ public class RestUtil {
      * @return True if the response is deemed successful, otherwise false
      *
      */
-    public static <T> boolean checkResponse(ResponseEntity<ResponseWrapper<T>> response) {
+    public static <T> boolean checkResponse(ResponseEntity<T> response) {
         if (response == null) {
             return false;
         } else if (response.getStatusCode().value() >= HttpStatus.BAD_REQUEST.value() ||


### PR DESCRIPTION
> Let's Try this again :smile: 

This should allow us to handle responses for single objects... such as the request

`http://secure-headland-8362.herokuapp.com/api/v1/user/119/`

executing a `GET` on that URL provides JSON for a single user.  It should return a single `User` Java Object... which we now support
